### PR TITLE
server now only accepts json, fixed lines bug

### DIFF
--- a/src/api/controllers/lines.js
+++ b/src/api/controllers/lines.js
@@ -27,7 +27,7 @@ function getLineById(req, res) {
             "message": "UnauthorizedError: Need to be logged in"
         });
     } else {
-        Line.findById(req.params._id).exec(function (err, line) {
+        Line.findById(req.params.id).exec(function (err, line) {
             if (err)
                 return res.send(err);
             res.status(200).json(line)

--- a/src/app.js
+++ b/src/app.js
@@ -28,7 +28,7 @@ var port = process.env.PORT || 3000;
 //app.use(favicon(__dirname + '/public/favicon.ico'));
 // app.use(logger('dev'));
 app.use(bodyParser.json());
-app.use(bodyParser.urlencoded({ extended: false }));
+// app.use(bodyParser.urlencoded({ extended: false }));
 app.use(cookieParser());
 // app.use(express.static(path.join(__dirname, 'public')));
 // // [SH] Set the app_client folder to serve static resources


### PR DESCRIPTION
Content-Type: application/json is now a thing, no need for more parsing!!

fixed a bug in controllers/lines where `getLineById` was using `req.params._id` instead of `req.params.id`