### PR TITLE
line status changes verified

### DIFF
--- a/src/api/controllers/lines.js
+++ b/src/api/controllers/lines.js
@@ -119,7 +119,7 @@ function deleteLine(req, res) {
 
 }
 
-// patch /lines/:id
+// patch /lines/:id/status
 // currently, only the status field is mutable this way
 function updateLineStatus(req, res) {
     if (!req.user._id) {

--- a/src/api/controllers/lines.js
+++ b/src/api/controllers/lines.js
@@ -57,8 +57,9 @@ function createLine(req, res) {
             //otherwise this is fine
 
             var line = Line();
-            line.user_id = req.user._id
-            line.employer_id = req.body.employer_id
+            line.user_id = req.user._id;
+            line.employer_id = req.body.employer_id;
+            line.status = 'preline';
             line.logEvent();
             line.save(function(err){
                 if(err)
@@ -77,6 +78,10 @@ function updateLine(req, res) {
         res.status(401).json({
             "message": "UnauthorizedError: Need to be logged in"
         });
+    } else if (req.user.user_type == 'student') {
+        req.status(401).json({
+            "message": "UnauthorizedError: Not available to students"
+        })
     } else {
         req.body.updated_by = new Date();
         Line.findByIdAndUpdate({_id: req.params.id}, req.body, {new: true}).exec(function (err, line) {
@@ -114,4 +119,36 @@ function deleteLine(req, res) {
 
 }
 
-export default { getLineByAuthUser, getLineById, createLine, updateLine, deleteLine }
+// patch /lines/:id
+// currently, only the status field is mutable this way
+function updateLineStatus(req, res) {
+    if (!req.user._id) {
+        res.status(401).json({
+            "message": "UnauthorizedError: Need to be logged in"
+        });
+    } else { 
+        Line.findById({_id: req.params.id}).exec(function (err, line) {
+            if (err) 
+                return res.send(err);
+            if (!line) {
+                res.status(400).json({
+                    "message": "No line found for parameter :id + " + req.params.id
+                });
+            } else {
+                const msg = line.updateStatus(req.body.status);
+
+                if (msg !== 'success') {
+                    res.status(400).json({
+                        "message": msg
+                    });
+                } else {
+                    res.status(200).json({
+                        "message": "Successfully updated line with status " + req.body.status
+                    });
+                }
+            }
+        });
+    }
+}
+
+export default { getLineByAuthUser, getLineById, createLine, updateLine, deleteLine, updateLineStatus }

--- a/src/api/models/lines.js
+++ b/src/api/models/lines.js
@@ -79,7 +79,7 @@ lineSchema.methods.updateStatus = function(status) {
             }
             break;
         case 'timeoutchurn':
-            if (this.status !== 'notification') {
+            if (this.status !== 'notification' && this.status !== 'inline' && this.status !== 'startrecruiter') {
                 msg = "LineUpdateError: Cannot time out when in status " + status;
             }
             break;
@@ -112,12 +112,12 @@ lineSchema.methods.updateStatus = function(status) {
         case 'finishrecruiter':
         case 'timeoutchurn':
         case 'voluntarychurn':
-        this.remove(function(err) {
-            if (err) {
-                console.log("LineUpdateError: Could not remove line: " + err);
-                return 'LineUpdateError: Could not remove line: ' + err;
-            }
-        });
+            this.remove(function(err) {
+                if (err) {
+                    console.log("LineUpdateError: Could not remove line: " + err);
+                    return 'LineUpdateError: Could not remove line: ' + err;
+                }
+            });
             break;
         default:
             break;

--- a/src/api/models/lines.js
+++ b/src/api/models/lines.js
@@ -52,16 +52,79 @@ lineSchema.methods.logEvent = function() {
 // update status of line
 // used for manually updating status, instead of using api route
 // also creates log event.
+// returns 'success' upon success, and an error message otherwise.
 lineSchema.methods.updateStatus = function(status) {
-    console.log("Line: Manually Updating Status: " + status);
+    var msg = null;
+    //verify that line progression is happening in order
+    switch (status) {
+
+        case 'notification':
+            if (this.status !== 'preline') {
+                msg = "LineUpdateError: Cannot move to notification status from status " + status;
+            }
+            break;
+        case 'inline':
+            if (this.status !== 'notification') {
+                msg = "LineUpdateError: Cannot move to inline status from status " + status;
+            }
+            break;
+        case 'startrecruiter':
+            if (this.status !== 'inline') {
+                msg = "LineUpdateError: Cannot move to startrecruiter status from status " + status;
+            }
+            break;
+        case 'finishrecruiter':
+            if (this.status !== 'startrecruiter') {
+                msg = "LineUpdateError: Cannot move to finishrecruiter status from status " + status;
+            }
+            break;
+        case 'timeoutchurn':
+            if (this.status !== 'notification') {
+                msg = "LineUpdateError: Cannot time out when in status " + status;
+            }
+            break;
+        case 'preline':
+            msg = "Cannot change status to preline - exit and reenter this line";
+            break;
+        case 'voluntarychurn':
+            break; //can enter or exit at any time
+        default:
+            msg = "Invalid status desired: " + status;
+            break;
+    }
+
+    if (msg !== null) {
+        return msg;
+    }
+
     this.status = status;
     this.updated_by = new Date();
     this.save(function(err, line) {
         if (err)
-            return console.log("LineUpdateError: " + err);
+            console.log("LineUpdateError: " + err);
+            return "LineUpdateError: " + err;
         
         line.logEvent();
     });
+
+    //delete if in end state
+    switch (status) {
+        case 'finishrecruiter':
+        case 'timeoutchurn':
+        case 'voluntarychurn':
+        this.remove(function(err) {
+            if (err) {
+                console.log("LineUpdateError: Could not remove line: " + err);
+                return 'LineUpdateError: Could not remove line: ' + err;
+            }
+        });
+            break;
+        default:
+            break;
+    }
+
+    msg = 'success';
+    return msg;
 }
 
 mongoose.model('Line', lineSchema);

--- a/src/api/routes/index.js
+++ b/src/api/routes/index.js
@@ -26,6 +26,7 @@ router.get('/lines/:id', auth, lineController.getLineById);
 router.post('/lines', auth, lineController.createLine);
 router.put('/lines/:id', auth, lineController.updateLine);
 router.delete('/lines/:id', auth, lineController.deleteLine);
+router.patch('/lines/:id', auth, lineController.updateLineStatus); //to update line status field
 
 // employers
 router.get('/employers', auth, employerController.getEmployerBySearch);

--- a/src/api/routes/index.js
+++ b/src/api/routes/index.js
@@ -26,7 +26,7 @@ router.get('/lines/:id', auth, lineController.getLineById);
 router.post('/lines', auth, lineController.createLine);
 router.put('/lines/:id', auth, lineController.updateLine);
 router.delete('/lines/:id', auth, lineController.deleteLine);
-router.patch('/lines/:id', auth, lineController.updateLineStatus); //to update line status field
+router.patch('/lines/:id/status', auth, lineController.updateLineStatus); //to update line status field
 
 // employers
 router.get('/employers', auth, employerController.getEmployerBySearch);

--- a/src/app.js
+++ b/src/app.js
@@ -39,7 +39,7 @@ app.use(passport.initialize());
 
 var options = {
     origin: '*',
-    methods: ['GET', 'POST', 'PUT', 'DELETE'],
+    methods: ['GET', 'POST', 'PUT', 'DELETE', 'PATCH'],
     allowedHeaders: ['Origin', 'Content-Type', 'Authorization', 'X-Requested-With', 'Accept'],
     preflightContinue: false,
     optionsSuccessStatus: 204


### PR DESCRIPTION
-PUT /lines/:id no longer available to students.
-PATCH /lines/:id now provided for student clients make changes to the status of a line. (Currently only supports changing the 'status' field)

-Each regular progression in the line's status can only follow from the directly previous one (there is a separate issue to allow skipping to inline from preline, haven't done this yet).
-Changing to preline is disallowed; delete your line and POST a new one.
-Timing out only allowed if in notification stage.
-Voluntary churn allowed anytime.

-When reaching an end state (FR, timeout, and voluntary churn), the line is then deleted (after a lineEvent is logged).
