### PR TITLE
QR refactor complete

### DIFF
--- a/src/api/controllers/authentication.js
+++ b/src/api/controllers/authentication.js
@@ -31,7 +31,8 @@ function register(req, res) {
 
             user.setPassword(req.body.password);
 
-            user.user_type = req.body.user_type;
+            //need to enforce default here since jwt builds off of this.
+            user.user_type = (req.body.user_type === undefined) ? 'student' : req.body.user_type;
             user.employer_id = req.body.employer_id;
 
             user.save(function (err) {

--- a/src/api/controllers/employers.js
+++ b/src/api/controllers/employers.js
@@ -1,5 +1,4 @@
 import mongoose from 'mongoose'
-import randomstring from 'randomstring'
 const User = mongoose.model('User');
 const Employer = mongoose.model('Employer');
 const Line = mongoose.model('Line');
@@ -96,69 +95,4 @@ function deleteEmployer(req, res) {
     }
 };
 
-// get /employers/:id/qr
-function getQRCodeById(req, res) {
-    console.log('test');
-    if (!req.user._id) {
-        res.status(401).json({
-            "message": response.unauthorized
-        });
-    } else if (req.user.user_type == 'student') {
-        req.status(401).json({
-            "message": response.authNoStudentsAllowed
-        })
-    } else {
-        Employer.findById(req.params.id).exec( function (err, employer){
-            if (err) {
-                res.send(err);
-            } else if (!employer) {
-                res.status(404).json({
-                    "message": "NotFoundError: No employer with this employer id"
-                });
-            } else {
-                if (employer.qr_code_value) {
-                    res.status(200).json(employer);
-                } else { //qr code value doesn't exist yet; generate it & save to employer
-                    employer.qr_code_value = randomstring.generate();
-                    employer.save( function (err){
-                        if (err)
-                            return res.send(err);
-                        res.status(200).json(employer);
-                    });
-                }
-            }
-        })
-    }
-};
-
-// post /employers/qr
-function getEmployerFromQRValue(req, res) {
-    if (!req.user._id) {
-        res.status(401).json({
-            "message": response.unauthorized 
-        });
-    } else if (!req.body.value) {
-        res.status(400).json({
-            "message": response.postEmployersQRMissingValueBody
-        });
-    } else {
-        const qr_value = req.body.value;
-        Employer.findOne({ qr_code_value: qr_value }).exec( function (err, employer){
-            if (err) {
-                res.send(err);
-            } else if (!employer) {
-                res.status(404).json({
-                    "message": "NotFoundError: No employer with this qr code value"
-                });
-            } else {
-                //TODO: ask brian if sending whole employer back or just emp_id is better practice
-                res.status(200).json(employer);
-                /*res.status(200).json({
-                    "employer_id": employer._id
-                })*/
-            }
-        })
-    }
-};
-
-export default { getEmployerById, getEmployerBySearch, createEmployer, updateEmployer, deleteEmployer, getQRCodeById, getEmployerFromQRValue}
+export default { getEmployerById, getEmployerBySearch, createEmployer, updateEmployer, deleteEmployer}

--- a/src/api/controllers/qrCodeValues.js
+++ b/src/api/controllers/qrCodeValues.js
@@ -1,0 +1,59 @@
+import mongoose from 'mongoose'
+const QRCodeValue = mongoose.model('QRCodeValue');
+
+import response from './response.js'
+
+//get /qr?employer_id=xxx (or qr_code_value=xxx)
+function getQRWithQuery(req, res) {
+	if (!req.user._id) {
+        res.status(401).json({
+            "message": response.unauthorized 
+        });
+    } else {
+    	if (req.query.employer_id) {
+    		return getQRByEmployerId(req, res);
+    	} else if (req.query.qr_code_value) {
+    		return getQRByCodeValue(req, res);
+    	} else {
+    		return res.status(400).json({
+    			"message": response.getQRMissingQuery
+    		});
+    	}
+    }
+}
+
+//helper for get /qr?employer_id=xxx
+function getQRByEmployerId(req, res) {
+	if (req.user.user_type === 'student') {
+        res.status(401).json({
+            "message": response.authNoStudentsAllowed
+        });
+    } else {
+        QRCodeValue.findOne({ employer_id: req.query.employer_id })
+        		   .sort({ created_by: -1 })
+        		   .exec(function (err, QRvalue) {
+            if (err)
+                return res.send(err);
+            if (!QRvalue) 
+            	return res.status(404).json({
+            		"message": response.getQRNotFound
+            	});
+            return res.status(200).json(QRvalue);
+        });
+    }
+}
+
+//helper for get /qr?qr_code_value=xxx
+function getQRByCodeValue(req, res) {
+	QRCodeValue.findOne({ qr_code_value: req.query.qr_code_value }).exec(function (err, QRvalue) {
+		if (err)
+			return res.send(err);
+		if (!QRvalue)
+        	return res.status(404).json({
+        		"message": response.getQRNotFound
+        	});
+        return res.status(200).json(QRvalue);
+	});
+}
+
+export default { getQRWithQuery }

--- a/src/api/controllers/response.js
+++ b/src/api/controllers/response.js
@@ -21,6 +21,10 @@ let messages =  {
     postEmployersMissingNameBody: "InputError: Missing name parameter in body",
     postEmployersQRMissingValueBody: "InputError: Missing value parameter in body",
 
+    // QR
+    getQRNotFound: "NotFound: no QR found for your input",
+    getQRMissingQuery: "InputError: Missing employer_id or qr_code_value as a query parameter in url",
+
     // misc
     success: "Success"
 

--- a/src/api/cron/cron.js
+++ b/src/api/cron/cron.js
@@ -7,6 +7,8 @@ import UpdateAllQRValues from './updateAllQRValues'
 // updateAllPrelineToNotification
 cron.schedule("*/5 * * * * *", UpdateAllPrelineToNotification.job)
 
-// every 10 minutes
+// every 5 minutes (timeout is 10; this way we have 2 QR codes available per employer at a time)
+// if you change this, consider changing the timeout value in UpdateAllQRValues.
 // updateAllQRValues
-cron.schedule("*/10 * * * *", UpdateAllQRValues.job)
+cron.schedule("*/5 * * * *", UpdateAllQRValues.job)
+//cron.schedule("*/15 * * * * *", UpdateAllQRValues.job) //debug: every 15 seconds

--- a/src/api/cron/updateAllQRValues.js
+++ b/src/api/cron/updateAllQRValues.js
@@ -1,9 +1,17 @@
 import mongoose from 'mongoose'
-import randomstring from 'randomstring'
 const Employer = mongoose.model('Employer');
+const QRCodeValue = mongoose.model('QRCodeValue');
 
-//every 10 minutes: give each employer a new random qr code value
+//10 minutes, measured in milliseconds.
+//If you change this, consider changing how frequently of this job as well.
+const timeout = 1000*60*10;
+//const timeout = 1000*30; //debug of 30 seconds
+
+//Delete expired code values
+//Give each employer a new random qr code value
 function job() {
+	QRCodeValue.deleteExpired();
+
 	var query = Employer.find({});
 	query.exec( function (err, employers) {
 		if (err) {
@@ -11,12 +19,8 @@ function job() {
 		}
 
 		employers.forEach( function (employer) {
-			employer.qr_code_value = randomstring.generate();
-			console.log('Created QR code value for employer %s, with %s', employer.name, employer.qr_code_value);
-            employer.save( function (err) {
-                if (err)
-                    return console.log("QRUpdaterError: " + err);
-            });
+			QRCodeValue.createValue(employer._id, timeout);
+			console.log('Created QR code value for employer %s', employer.name);
 		});
 	});
 }

--- a/src/api/models/db.js
+++ b/src/api/models/db.js
@@ -60,3 +60,4 @@ require('./employers');
 require('./users');
 require('./lineEvents');
 require('./lines');
+require('./qrCodeValues');

--- a/src/api/models/employers.js
+++ b/src/api/models/employers.js
@@ -6,12 +6,6 @@ var employerSchema = new mongoose.Schema({
         unique: true,
         required: true,
     },
-    qr_code_value: {
-    	type: String,
-    	unique: true,
-    	default: null,
-    	index: true
-    },
     created_by: {
         type: Date,
         default: Date.now,

--- a/src/api/models/qrCodeValues.js
+++ b/src/api/models/qrCodeValues.js
@@ -1,0 +1,60 @@
+import mongoose from 'mongoose'
+import idvalidator from 'mongoose-id-validator'
+import randomstring from 'randomstring'
+const Schema = mongoose.Schema;
+const Employer = mongoose.model('Employer');
+
+var qrCodeValueSchema = new Schema({
+    qr_code_value: {
+        type: String,
+        unique: true,
+        required: true,
+        default: null,
+        index: true
+    },
+    employer_id: {
+        type: Schema.Types.ObjectId,
+        ref: 'Employer',
+        required: true,
+        default: null,
+        index: true
+    },
+    created_by: {
+        type: Date,
+        default: Date.now
+    },
+    finished_by: {
+        type: Date,
+        default: null
+    }
+});
+
+qrCodeValueSchema.plugin(idvalidator);
+
+// for use by cron job
+// timeout is in milliseconds
+qrCodeValueSchema.statics.createValue = function (employer_id, timeout) {
+    var newQR = new this();
+
+    newQR.qr_code_value = randomstring.generate();
+    newQR.employer_id = employer_id;
+    newQR.created_by = Date.now();
+    newQR.finished_by = Date.now() + timeout;
+
+    newQR.save(function(err) {
+        if (err) 
+            console.log("Error creating a QR code: " + err);
+    });
+}
+
+// for use by cron job
+qrCodeValueSchema.statics.deleteExpired = function () {
+    const curDate = Date.now();
+
+    this.remove({ finished_by: {$lt: curDate} }).exec(function(err) {
+        if (err)
+            console.log("Error deleting expired QR codes: " + err);
+    });
+}
+
+module.exports = mongoose.model('QRCodeValue', qrCodeValueSchema);

--- a/src/api/models/users.js
+++ b/src/api/models/users.js
@@ -84,6 +84,7 @@ UsersSchema.methods.generateJwt = function () {
         _id: this._id,
         email: this.email,
         name: this.name,
+        user_type: this.user_type,
         exp: parseInt(expiry.getTime() / 1000),
     }, process.env.SECRET);
 };

--- a/src/api/routes/index.js
+++ b/src/api/routes/index.js
@@ -11,6 +11,7 @@ import authController from '../controllers/authentication'
 import userController from '../controllers/users'
 import lineController from '../controllers/lines'
 import employerController from '../controllers/employers'
+import qrController from '../controllers/qrCodeValues'
 
 // authentication
 router.post('/register', authController.register);
@@ -37,8 +38,7 @@ router.post('/employers', auth, employerController.createEmployer);
 router.put('/employers/:id', auth, employerController.updateEmployer);
 router.delete('/employers/:id', auth, employerController.deleteEmployer);
 
-
-router.get('/employers/:id/qr', auth, employerController.getQRCodeById) //get qr code value for company
-router.post('/employers/qr', auth, employerController.getEmployerFromQRValue) //given qr value, returns emp id
+// QR
+router.get('/qr', auth, qrController.getQRWithQuery); //get qr code given emp_id or qr_code_value in query
 
 module.exports = router;


### PR DESCRIPTION

-Removed QR stuff from /employers controller and model.
-Added /qr controller and model. QR codes have
-Tweaked cron job to work with static methods from the QR schema.
-Default lifetime of a QR code is 10 minutes.
-QR codes are swept and regenerated every 5 minutes (so effectively there are 2 per employer at any given time.)

API changes:
-I have an employer_id and I want a QR object. (recruiter tablet)
Before: GET /employers/:id/qr
Now: GET /qr?employer_id=xxx
This is unavailable to students.

-I have a QR code value that I scanned, and I want the whole object. (student phone)
Before: POST /employers/qr 
Now: GET /qr?qr_code_value=xxx

Bugfixes:
-jwt wasn't including user_type, so our checks to disallow students from certain routes weren't actually working. This is now fixed