### PR TITLE
implemented data fields, added /model/auth routes, unauthed /employers

### DIFF
--- a/src/api/controllers/response.js
+++ b/src/api/controllers/response.js
@@ -10,7 +10,15 @@ let messages =  {
     authLoginInvalid: "LoginError: Invalid email password combination",
 
     // authentication off user type
-    authNoStudentsAllowed: "UnauthorizedError: Not available to students",
+    onlyStudent: "UnauthorizedError: Only available to students",   
+    notStudent: "UnauthorizedError: Not available to students",   
+    onlyRecruiters: "UnauthorizedError: Only available to recruiters",   
+    notRecruiters: "UnauthorizedError: Not available to recruiters",   
+    onlyAdmins: "UnauthorizedError: Only available to admins",   
+
+    // users
+    getUsersOnlyAdmin: "UnauthorizedError: Only available to admin",
+    patchUsersMissingDataBody: "InputError: Missing data in body",
 
     // lines
     postLinesAlreadyExists: "UniqueError: Line for this user already exists",
@@ -20,6 +28,7 @@ let messages =  {
     // getEmployersMissingNameQuery: "InputError: Missing name parameter in query",
     postEmployersMissingNameBody: "InputError: Missing name parameter in body",
     postEmployersQRMissingValueBody: "InputError: Missing value parameter in body",
+    patchEmployersMissingDataBody: "InputError: Missing data in body",
 
     // QR
     getQRNotFound: "NotFound: no QR found for your input",

--- a/src/api/controllers/users.js
+++ b/src/api/controllers/users.js
@@ -2,18 +2,43 @@ import mongoose from 'mongoose'
 const User = mongoose.model('User');
 const Line = mongoose.model('Line');
 
-// get /users
+import response from './response.js'
+
+//get /users
+function getUsers(req, res) {
+
+    if (!req.user._id) {
+        res.status(401).json({
+            "message": response.unauthorized
+        });
+    } else if (req.user.user_type !== 'admin') { // restricted to admin
+        res.status(401).json({
+            "message": response.getUsersOnlyAdmin
+        });
+    } else {
+        User.find({ }).exec(function (err, users) {
+            if (err)
+                return res.send(err);
+            res.status(200).json({
+                "users": users
+            });
+        });
+    }
+
+}
+
+// get /users/auth
 function getUserByAuthUser(req, res) {
 
     if (!req.user._id) {
         res.status(401).json({
-            "message": "UnauthorizedError: Need to be logged in"
+            "message": response.unauthorized
         });
     } else {
         User.findById(req.user._id).exec(function (err, user) {
             if (err)
-                res.send(err);
-            res.status(200).json(user)
+                return res.send(err);
+            res.status(200).json(user);
         });
     }
 
@@ -24,16 +49,40 @@ function getUserById(req, res) {
 
     if (!req.user._id) {
         res.status(401).json({
-            "message": "UnauthorizedError: Need to be logged in"
+            "message": response.unauthorized
         });
     } else {
         User.findById(req.params.id).exec(function (err, user) {
             if (err)
-                res.send(err);
-            res.status(200).json(user)
+                return res.send(err);
+            res.status(200).json(user);
         });
     }
 
 }
 
-export default { getUserByAuthUser, getUserById } 
+//patch /users/auth/data
+function patchUserDataByAuthUser(req, res) {
+
+    if (!req.user._id) {
+        res.status(401).json({
+            "message": response.unauthorized
+        });
+    } else if (!req.body.data) {
+        res.status(400).json({
+            "message": response.patchUsersMissingDataBody
+        });
+    } else {
+        User.findById(req.user._id).exec(function (err, user){
+            user.data = req.body.data;
+            user.save( function(err, user) {
+                if (err)
+                    return res.send(err);
+                res.status(200).json(user);
+            });
+        })
+    }
+
+}
+
+export default { getUsers, getUserByAuthUser, getUserById, patchUserDataByAuthUser } 

--- a/src/api/models/employers.js
+++ b/src/api/models/employers.js
@@ -6,10 +6,14 @@ var employerSchema = new mongoose.Schema({
         unique: true,
         required: true,
     },
+    data: {
+        type: Object,
+        default: {}
+    },
     created_by: {
         type: Date,
         default: Date.now,
-    },
+    }
 });
 
 mongoose.model('Employer', employerSchema);

--- a/src/api/models/users.js
+++ b/src/api/models/users.js
@@ -24,6 +24,10 @@ var UsersSchema = new Schema({
         type: String,
         select: false
     },
+    data: {
+        type: Object,
+        default: {}
+    },
     created_by: {
         type: Date,
         default: Date.now

--- a/src/api/routes/index.js
+++ b/src/api/routes/index.js
@@ -18,7 +18,9 @@ router.post('/register', authController.register);
 router.post('/login', authController.login);
 
 // users
-router.get('/users', auth, userController.getUserByAuthUser);
+router.get('/users', auth, userController.getUsers);
+router.get('/users/auth', auth, userController.getUserByAuthUser);
+router.patch('/users/auth/data', auth, userController.patchUserDataByAuthUser);
 router.get('/users/:id', auth, userController.getUserById);
 
 // lines
@@ -32,10 +34,12 @@ router.delete('/lines/:id', auth, lineController.deleteLine);
 router.patch('/lines/:id/status', auth, lineController.updateLineStatus); //to update line status field
 
 // employers
-router.get('/employers', auth, employerController.getEmployerBySearch);
-router.get('/employers/:id', auth, employerController.getEmployerById);
+router.get('/employers', employerController.getEmployerBySearch); // UNAUTHENTICATED
+router.get('/employers/auth', auth, employerController.getEmployerByAuthUser);
+router.get('/employers/:id', employerController.getEmployerById); // UNAUTHENTICATED
 router.post('/employers', auth, employerController.createEmployer);
 router.put('/employers/:id', auth, employerController.updateEmployer);
+router.patch('/employers/auth/data', auth, employerController.patchEmployersDataByAuthUser); // recruiter only
 router.delete('/employers/:id', auth, employerController.deleteEmployer);
 
 // QR


### PR DESCRIPTION
- added `data` field to users and employers
- added /users/auth/data and /employers/auth/data (for recruiter only)
- added /users/auth and /employers/auth (for recruiter only)
- /users is now an admin only field to query for all users
- /employers and /employers/:id is now an UNAUTHENTICATED ROUTE, PUBLIC per front end request
- /employers with no name parameter is now an array off of "employers" key.
