### PR TITLE
GET /lines/users now also gives line ids

### DIFF
--- a/src/api/controllers/lines.js
+++ b/src/api/controllers/lines.js
@@ -272,10 +272,7 @@ function getUsersByEmployerId(req, res) {
         query.exec(function (err, lines) {
             if (err)
                 return res.send(err);
-            /*for (var i = 0; i < lines.length; i++) {
-                user_ids[i] = lines[i].user_id;
-                line_ids[i] = lines[i]._id;
-            }*/
+
             user_ids = lines.map(line => line.user_id);
             line_ids = lines.map(line => line._id);
         }).then(function () {


### PR DESCRIPTION
GET /lines/users now returns the users (like it did before) with an extra field per user (new): their line_id for the employer of the currently authenticated recruiter. 

Now the recruiters can start and finish interviews properly in the front end.

There is probably a more sophisticated way to do this. I looked into populate() and aggregate() to emulate joins. The problem is that it is a major PITA to join on more than one field at a time in mongoose/mongodb, and since Line has a composite key of user_id and employer_id, we need to join on both those fields. (We need to join on employer_id too, because eventually we're looking to let students join both a normal and virtual line, and we don't want our join to pick up normal lines.)

I tested this with 1 person in the active batch and also with 4, making sure the line_ids returned with the corresponding users really did match the user_ids found when querying for that line.

Comments from the code:
lean() is used so that the 'users' returned are plain JS objects (as opposed to actual mongoose documents) that we can modify before sending to the client. We just need to tack on the line_id and off it goes.

There is no guarantee that the order of the users returned by the User query will match the order of the lines/user ids found by the Line query, so there is some looping to match them up. This is inefficient (and would be unnecessary if I implemented multi-attribute joining), but the batch size is really low so it shouldn't matter.
