### PR TITLE
implemented passcode for recruiter registration see #15

### DIFF
--- a/src/api/controllers/employers.js
+++ b/src/api/controllers/employers.js
@@ -72,12 +72,15 @@ function createEmployer(req, res) {
             "message": response.postEmployersMissingNameBody
         });
     } else {
-        var employer = Employer();
-        employer.name = req.body.name
-        employer.save(function(err){
+        var newEmployer = Employer();
+        newEmployer.name = req.body.name;
+        newEmployer.passcode = Employer.generateRandomCode();
+
+        //if randomly generated code happens to be a duplicate, just have client try again.
+        newEmployer.save(function(err){
             if(err)
                 return res.send(err);
-            res.status(200).json(employer);
+            res.status(200).json(newEmployer);
         });
     }
 };

--- a/src/api/controllers/response.js
+++ b/src/api/controllers/response.js
@@ -5,6 +5,8 @@ let messages =  {
     // authentication
     userAlreadyExists: "RegisterError: User already exists!",
     authRegisterMissingFields: "RegisterError: Need name, email, and password",
+    authRegisterNoEmployerFound: "RegisterError: No employer found with that passcode",
+    authRegisterWithEmpIdNotAllowed: "RegisterError: Passing in employer_id is not allowed. Use company passcode",
     authLoginMissingFields: "LoginError: Need email and password fields",
     authLoginNoUserFound: "LoginError: No user found for email",
     authLoginInvalid: "LoginError: Invalid email password combination",

--- a/src/api/models/employers.js
+++ b/src/api/models/employers.js
@@ -1,5 +1,7 @@
 import mongoose from 'mongoose'
 
+const EMPLOYER_LIMIT = 900000;
+
 var employerSchema = new mongoose.Schema({
     name: {
         type: String,
@@ -11,10 +13,21 @@ var employerSchema = new mongoose.Schema({
         type: Object,
         default: {}
     },
+    passcode: {
+        type: Number,
+        unique: true,
+        required: true,
+        index: true
+    },
     created_by: {
         type: Date,
         default: Date.now,
     }
 });
+
+//helper: generate random 6-digit code
+employerSchema.statics.generateRandomCode = function() {
+    return Math.floor(Math.random() * EMPLOYER_LIMIT + 100000);
+}
 
 mongoose.model('Employer', employerSchema);

--- a/src/api/models/users.js
+++ b/src/api/models/users.js
@@ -45,7 +45,7 @@ var userSchema = new Schema({
            so we can verify that user_type is recruiter. */
         required: [function() {
             return this.employer_id !== undefined;
-        }, 'If employer_id is specified, user_type must be recruiter'],
+        }, 'If company passcode is specified, user_type must be recruiter'],
 
         validator: function(v, cb) {
             if (v === 'recruiter') {
@@ -66,7 +66,7 @@ var userSchema = new Schema({
         ref: 'Employer',
         required: [function() {
             return this.user_type === 'recruiter';
-        }, 'If user_type is recruiter, employer_id must be specified'],
+        }, 'If user_type is recruiter, need correct company passcode'],
         default: null
     }
 });


### PR DESCRIPTION
Added some error responses

Company passcode is a randomly generated 6 digit number from 100000-999999
It gets automatically created via the POST /employers route

Recruiter registration: now disallows employer_id explicitly. Use "passcode" instead.
I did discover that the registration validation is not quite working perfectly (see #117), but the bug is minor. The happy path and some failure cases work properly.

