### PR TITLE
stats route now specifies employer_id is required

### DIFF
--- a/src/api/controllers/lines.js
+++ b/src/api/controllers/lines.js
@@ -132,6 +132,12 @@ function deleteLine(req, res) {
 // get /lines/auth/stats?employer_id=xxx
 function getStatsByEmployerId(req, res) {
 
+    if (!req.query.employer_id) {
+        return res.status(400).json({
+            "message": response.getLineStatsMissingEmployerId
+        });
+    }
+
     //use promises to have queries run async. in parallel.
     var size = getSizeByEmployerId(req.query.employer_id)
     var currentPlace = getMyPlaceByEmployerId(req.user._id, req.query.employer_id)
@@ -150,6 +156,13 @@ function getStatsByEmployerId(req, res) {
 // get /lines/stats?employer_id=xxx
 // UNAUTHENTICATED
 function getStatsByEmployerIdNoAuth(req, res) {
+
+    if (!req.query.employer_id) {
+        return res.status(400).json({
+            "message": response.getLineStatsMissingEmployerId
+        });
+    }
+
     var size = getSizeByEmployerId(req.query.employer_id);
     
     //obviously Promise.all is overkill for only 1 statistic, but we plan to add more later anyway.

--- a/src/api/controllers/response.js
+++ b/src/api/controllers/response.js
@@ -25,6 +25,7 @@ let messages =  {
     // lines
     postLinesAlreadyExists: "UniqueError: Line for this user already exists",
     getLinesUsersMissingEmployerId: "InputError: Needs employer_id as a query parameter in url",
+    getLineStatsMissingEmployerId: "InputError: Needs employer_id as a query parameter in url",
 
     // lineEvents
     getLineEventsByAuthUserUnauthorizedUserIdQuery: "UnauthorizedError: Attempting to access other user line info. Don't put user_id in your query",


### PR DESCRIPTION
if employer_id query parameter is blank, a proper error is returned stating that this field is required.
This is both for the authenticated and unauthenticated GET line stats routes.