### PR TITLE
GET /lines/users now pulls emp_id from auth token

### DIFF
--- a/src/api/models/users.js
+++ b/src/api/models/users.js
@@ -87,13 +87,25 @@ userSchema.methods.generateJwt = function () {
     var expiry = new Date();
     expiry.setDate(expiry.getDate() + 7);
 
-    return jwt.sign({
-        _id: this._id,
-        email: this.email,
-        name: this.name,
-        user_type: this.user_type,
-        exp: parseInt(expiry.getTime() / 1000),
-    }, process.env.SECRET);
+    if (this.user_type === 'recruiter') {
+        return jwt.sign({
+            _id: this._id,
+            email: this.email,
+            name: this.name,
+            user_type: this.user_type,
+            employer_id: this.employer_id,
+            exp: parseInt(expiry.getTime() / 1000),
+        }, process.env.SECRET);
+    } else {
+        return jwt.sign({
+            _id: this._id,
+            email: this.email,
+            name: this.name,
+            user_type: this.user_type,
+            exp: parseInt(expiry.getTime() / 1000),
+        }, process.env.SECRET);
+    }
+
 };
 
 module.exports = mongoose.model('User', userSchema);


### PR DESCRIPTION
implements #98 and #99 

GET /lines/users is now accessible without a query ?employer_id=xxx.
if auth_user is a recruiter, the emp_id is pulled directly from the recruiter automatically.
else, the query is used.
Effectively this means that recruiters are only limited to seeing their own active batch (they can't query for other companies), which makes sense.
