### PR TITLE
company profiles ready

### DIFF
--- a/src/api/controllers/employers.js
+++ b/src/api/controllers/employers.js
@@ -96,37 +96,40 @@ function deleteEmployer(req, res) {
             res.send(err);
         res.status(200).json({
             "message": response.success
-        })
-    })
+        });
+    });
     
 };
 
-// patch employers/auth/data
-function patchEmployersDataByAuthUser(req, res) {
+// patch employers/auth/profile
+function patchEmployersProfileByAuthUser(req, res) {
 
     if (req.user.user_type !== 'recruiter') {
         res.status(401).json({
             "message": response.onlyRecruiters
         });
-    } else if (!req.body.data) {
+    } else if (!req.body) {
         res.status(400).json({
             "message": response.patchEmployersMissingDataBody 
         });
     } else {
-        User.findById(req.user._id).exec( function(err, user){
-            if (err)
-                return res.send(err);
-            Employer.findById(user.employer_id).exec( function(err, employer){
-                employer.data = req.body.data;
-                employer.save( function(err, employer){
+
+        try {
+            return Employer.findById(req.user.employer_id).exec(function(err, employer) {
+                employer.profile = req.body;
+                employer.save(function(err, employer) {
                     if (err)
                         return res.send(err);
-                    res.status(200).json(employer);
+                    return res.status(200).json(employer);
                 });
             });
-        });
+        } catch (err) {
+            return res.status(500).json({
+                "message": err
+            });
+        }
     }
-};
+}
 
-export default { getEmployerBySearch, getEmployerByAuthUser, getEmployerById, createEmployer, updateEmployer, deleteEmployer, patchEmployersDataByAuthUser }
+export default { getEmployerBySearch, getEmployerByAuthUser, getEmployerById, createEmployer, updateEmployer, deleteEmployer, patchEmployersProfileByAuthUser }
 

--- a/src/api/controllers/response.js
+++ b/src/api/controllers/response.js
@@ -34,7 +34,7 @@ let messages =  {
     // getEmployersMissingNameQuery: "InputError: Missing name parameter in query",
     postEmployersMissingNameBody: "InputError: Missing name parameter in body",
     postEmployersQRMissingValueBody: "InputError: Missing value parameter in body",
-    patchEmployersMissingDataBody: "InputError: Missing data in body",
+    patchEmployersMissingDataBody: "InputError: Missing profile fields in body",
 
     // QR
     getQRNotFound: "NotFound: no QR found for your input",

--- a/src/api/models/employers.js
+++ b/src/api/models/employers.js
@@ -2,6 +2,21 @@ import mongoose from 'mongoose'
 
 const EMPLOYER_LIMIT = 900000;
 
+var employerProfileSchema = new mongoose.Schema({
+    info: {
+        type: String
+    },
+    links: {
+        type: [String]
+    },
+    location: {
+        type: [Number]
+    },
+    attendance_date: {
+        type: Date
+    },
+});
+
 var employerSchema = new mongoose.Schema({
     name: {
         type: String,
@@ -9,9 +24,8 @@ var employerSchema = new mongoose.Schema({
         required: true,
         index: true
     },
-    data: {
-        type: Object,
-        default: {}
+    profile: {
+        type: employerProfileSchema
     },
     passcode: {
         type: Number,

--- a/src/api/routes/index.js
+++ b/src/api/routes/index.js
@@ -46,7 +46,7 @@ router.get('/employers/auth', auth, employerController.getEmployerByAuthUser);
 router.get('/employers/:id', employerController.getEmployerById); // UNAUTHENTICATED
 router.post('/employers', auth, employerController.createEmployer);
 router.put('/employers/:id', auth, employerController.updateEmployer);
-router.patch('/employers/auth/data', auth, employerController.patchEmployersDataByAuthUser); // recruiter only
+router.patch('/employers/auth/profile', auth, employerController.patchEmployersProfileByAuthUser); // recruiter only
 router.delete('/employers/:id', auth, employerController.deleteEmployer);
 
 // QR


### PR DESCRIPTION
Profile data is now a subschema that lives within Employer, in a field called profile.

Company profiles:
info: String
links: array of String
location: array of Number (intended to be coordinates)
attendance_date: Date

Changed PATCH /employers/auth/data to PATCH /employers/auth/profile
When using this route, just throw in the profile fields directly. Don't wrap them in a "profile" field. Obviously we can change this depending on convenience to front end.