### PR TITLE
user and recruiter profiles implemented with discriminators

### DIFF
--- a/src/api/controllers/response.js
+++ b/src/api/controllers/response.js
@@ -21,6 +21,7 @@ let messages =  {
     // users
     getUsersOnlyAdmin: "UnauthorizedError: Only available to admin",
     patchUsersMissingDataBody: "InputError: Missing data in body",
+    profileNoAdmins: "UnauthorizedError: Admins don't have profiles",
 
     // lines
     postLinesAlreadyExists: "UniqueError: Line for this user already exists",

--- a/src/api/controllers/users.js
+++ b/src/api/controllers/users.js
@@ -1,5 +1,6 @@
 import mongoose from 'mongoose'
-const User = mongoose.model('User');
+import { User, Student, Recruiter } from '../models/users.js'
+
 const Line = mongoose.model('Line');
 
 import response from './response.js'
@@ -45,24 +46,57 @@ function getUserById(req, res) {
 
 }
 
-//patch /users/auth/data
-function patchUserDataByAuthUser(req, res) {
+//patch /users/auth/profile
+//you can only modify your own profile.
+function patchProfileByAuthUser(req, res) {
 
-    if (!req.body.data) {
-        res.status(400).json({
-            "message": response.patchUsersMissingDataBody
-        });
-    } else {
-        User.findById(req.user._id).exec(function (err, user){
-            user.data = req.body.data;
-            user.save( function(err, user) {
-                if (err)
-                    return res.send(err);
-                res.status(200).json(user);
+    if (req.user.user_type === 'student') {
+
+        try {
+            return Student.findOneAndUpdate(
+                { _id: req.user._id }, req.body, {new: true})
+                .exec(function(err, student) {
+
+                if (err) {
+                    return res.status(500).json({
+                        "message": err
+                    });
+                }
+
+                return res.status(200).json(student);
             });
-        })
-    }
+        } catch (err) {
+            return res.status(500).json({
+                "message": err
+            });
+        }
+        
+    } else if (req.user.user_type === 'recruiter') {
 
+        try {
+            return Recruiter.findOneAndUpdate(
+                { _id: req.user._id }, req.body, {new: true})
+                .exec(function(err, recruiter) {
+
+                if (err) {
+                    return res.status(500).json({
+                        "message": err
+                    });
+                }
+
+                return res.status(200).json(recruiter);
+            });
+        } catch (err) {
+            return res.status(500).json({
+                "message": err
+            });
+        }
+
+    } else {
+        return res.status(401).json({
+            "message": response.profileNoAdmins
+        });
+    }
 }
 
-export default { getUsers, getUserByAuthUser, getUserById, patchUserDataByAuthUser } 
+export default { getUsers, getUserByAuthUser, getUserById, patchProfileByAuthUser } 

--- a/src/api/models/users.js
+++ b/src/api/models/users.js
@@ -26,10 +26,6 @@ var userSchema = new Schema({
         type: String,
         select: false
     },
-    data: {
-        type: Object,
-        default: {}
-    },
     created_by: {
         type: Date,
         default: Date.now
@@ -69,6 +65,39 @@ var userSchema = new Schema({
         }, 'If user_type is recruiter, need correct company passcode'],
         default: null
     }
+}, { 
+    discriminatorKey: 'user_type' 
+});
+
+var studentProfileSchema = new Schema({
+    major: {
+        type: String
+    },
+    gpa: {
+        type: Number
+    },
+    bio: {
+        type: String
+    },
+    grad_date: {
+        type: String //let users customize how they want to display it.
+    },
+    links: {
+        type: [String] //array
+    }
+}, {
+    discriminatorKey: 'user_type'
+});
+
+var recruiterProfileSchema = new Schema({
+    bio: {
+        type: String
+    },
+    job_title: {
+        type: String
+    }
+}, {
+    discriminatorKey: 'user_type'
 });
 
 userSchema.plugin(idvalidator);
@@ -108,4 +137,8 @@ userSchema.methods.generateJwt = function () {
 
 };
 
-module.exports = mongoose.model('User', userSchema);
+var User = mongoose.model('User', userSchema);
+var Student = User.discriminator('student', studentProfileSchema);
+var Recruiter = User.discriminator('recruiter', recruiterProfileSchema);
+
+module.exports = { User, Student, Recruiter };

--- a/src/api/routes/index.js
+++ b/src/api/routes/index.js
@@ -21,7 +21,7 @@ router.post('/login', authController.login);
 // users
 router.get('/users', auth, userController.getUsers);
 router.get('/users/auth', auth, userController.getUserByAuthUser);
-router.patch('/users/auth/data', auth, userController.patchUserDataByAuthUser);
+router.patch('/users/auth/profile', auth, userController.patchProfileByAuthUser);
 router.get('/users/:id', auth, userController.getUserById);
 
 // lines


### PR DESCRIPTION
-Changed PATCH /users/auth/data to PATCH /users/auth/profile
-Removed data field from user

-Added student profile and recruiter profile schemas on top of User, using discriminators, with key 'user_type'. This means that when you query for all users, you will also automatically be given their profile data along with name, email, etc. So no other route modifications are needed (if you want a user's profile, just do GET /users/:id which already exists). One nice feature of this is that when a recruiter views their active batch, all of the students' profile info is right there automatically, as long as the students have actually made their profiles to begin with.

-When modifying your profile, mongoose checks that the fields you pass in actually exist in your corresponding profile schema. 
Ex: I tried updating a recruiter's profile with "job_title" and "grad_date" and the request went through. The updated recruiter model that it sent back only had a "job_title" field.

Student profiles:
bio: String
major: String
gpa: Number
grad_date: String
links: array of String

Recruiter profiles:
bio: String
job_title: String

It would probably be prudent to move employer_id to the Recruiter schema, but I'll have to mess around with the User validation logic to make this work, so that can be a separate ticket.