### PR TITLE
response includes # of items deleted

### DIFF
--- a/src/api/controllers/lines.js
+++ b/src/api/controllers/lines.js
@@ -121,12 +121,20 @@ function updateLine(req, res) {
 // delete /lines/:id
 function deleteLine(req, res) {
 
-    Line.remove({_id: req.params.id}).exec(function (err, line) {
+    Line.remove({_id: req.params.id}).exec(function (err, removedInfo) {
         if (err)
             return res.send(err);
-        res.status(200).json({
-            "message": response.success
-        })
+        let numRemoved = removedInfo.result.n; //remove() returns a promise with some info, but not a line itself
+        if (numRemoved > 0) {
+            return res.status(200).json({
+                "message": response.deleteSuccess(numRemoved)
+            });
+        } else {
+            return res.status(404).json({
+                "message": response.deleteNotFound
+            });
+        }
+
     })
 
 }

--- a/src/api/controllers/response.js
+++ b/src/api/controllers/response.js
@@ -43,7 +43,9 @@ let messages =  {
     getQRMissingQuery: "InputError: Missing employer_id or qr_code_value as a query parameter in url",
 
     // misc
-    success: "Success"
+    success: "Success",
+    deleteSuccess: (num) => "Success: Deleted " + num + " element(s)", //assumes num > 0
+    deleteNotFound: "NotFound: Queried item(s) don't exist"
 
 }
 


### PR DESCRIPTION
implements #126 

so now delete no longer just returns "success" if it ran without errors, it actually tells the client whether/how many lines were deleted

this should probably be done for the other DELETE routes as well. This might be a good ticket for naren