### PR TITLE
added user_type validation in auth controller

### DIFF
--- a/src/api/controllers/authentication.js
+++ b/src/api/controllers/authentication.js
@@ -44,7 +44,10 @@ function register(req, res) {
                     user = new Admin();
                     break;
                 default:
-                    user = new User();
+                    return res.status(400).json({
+                        "message": response.authRegisterBadType
+                    });
+                    //user = new User();
                     break;
             }
 
@@ -95,7 +98,8 @@ function saveUser(res, user) {
             token = user.generateJwt();
             res.status(200);
             return res.json({
-                "token": token
+                "token": token,
+                "message": response.authRegisterSuccess(user)
             });
         } else {
             console.log(err);

--- a/src/api/controllers/response.js
+++ b/src/api/controllers/response.js
@@ -3,11 +3,13 @@ let messages =  {
     unauthorized: "UnauthorizedError: Need to be logged in",
 
     // authentication
+    authRegisterSuccess: (user) => "Successfully registered " + user.name + " as type " + user.user_type,
     userAlreadyExists: "RegisterError: User already exists!",
     authRegisterMissingFields: "RegisterError: Need name, email, and password",
     authRegisterNoEmployerFound: "RegisterError: No employer found with that passcode",
     authRegisterWithEmpIdNotAllowed: "RegisterError: Passing in employer_id is not allowed. Use company passcode",
     authRegisterRecruiterNoPasscode: "RegisterError: If recruiter, must pass in company passcode",
+    authRegisterBadType: "RegisterError: Invalid user_type",
     authLoginMissingFields: "LoginError: Need email and password fields",
     authLoginNoUserFound: "LoginError: No user found for email",
     authLoginInvalid: "LoginError: Invalid email password combination",


### PR DESCRIPTION
I made #117 with the intent of restricting registration if a passcode is required without specifying user type recruiter. Since then, I think it's simpler to just ignore passcode if user type isn't recruiter. I did notice in tests that user_type can be set to anything and our system will allow it, which is not what we want. Users must be exclusively students, recruiters, or admins.

So:
-Validated that user type is student, recruiter, or admin
-Added a success message when registration happens, confirming to the client the name and user_type of the user that was just registered