### PR TITLE
implemented favorites

### DIFF
--- a/src/api/models/users.js
+++ b/src/api/models/users.js
@@ -58,6 +58,9 @@ var studentSchema = new Schema({
     },
     locations_desired: {
         type: [String]
+    },
+    favorites: {
+        type: [String]
     }
 }, options);
 


### PR DESCRIPTION
Each Student now has a list of companies that are their favorites.
This is implemented as a field "favorites", array of String (meant to be employer IDs. The comparison logic didn't work with Schema.types.ObjectID)

Changed route GET /employers/auth:
Before:
-recruiter only, returns only the company that you work for.

Now:
-If recruiter, behaves as above
-If student: 
1) Can query for a company by name.
2) Can leave out the query to get all employers.

In either case, with each company that is returned, the backend will check if that student has that company favorited. If it is a favorite, then that company will have an additional field "favorite", set to "true." If it is not a favorite, that company will not have a "favorite" field at all.

-If admin:
Calls the unauthenticated route, with identical functionality (admin can either query by name or get a list of all employers).
