### PR TITLE
implemented favorite companies

### DIFF
--- a/src/api/controllers/users.js
+++ b/src/api/controllers/users.js
@@ -107,17 +107,17 @@ function getFavoritesByAuthUser(req, res) {
             "message": response.onlyStudent
         });
     } else {
-        try {
-            User.findById(req.user._id).populate('favorites').exec(function(err, user) {
-                return res.status(200).json({
-                    "favorites": user.favorites
+        User.findById(req.user._id).populate('favorites').exec(function(err, user) {
+            if (err) {
+                return res.status(500).json({
+                    "message": err
                 });
+            }
+
+            return res.status(200).json({
+                "favorites": user.favorites
             });
-        } catch (err) {
-            return res.status(500).json({
-                "message": err
-            });
-        }
+        });
     }
 }
 
@@ -130,46 +130,46 @@ function patchFavoritesByAuthUser(req, res) {
             "message": response.onlyStudent
         });
     } else {
-        try {
-            User.findById(req.user._id).exec(async function(err, user) {
-            //User.findById(req.user._id).populate('favorites').exec(async function(err, user) {
-                /*return res.status(200).json({
-                    "favorites": user.favorites
-                });*/
-                var toggleId = req.body.employer_id;
-                var toggleIdIsFavorite = user.favorites.some(emp_id => {
-                    return emp_id.equals(toggleId);
+        User.findById(req.user._id).exec(async function(err, user) {
+        //User.findById(req.user._id).populate('favorites').exec(async function(err, user) {
+            /*return res.status(200).json({
+                "favorites": user.favorites
+            });*/
+            if (err) {
+                return res.status(500).json({
+                    "message": err
                 });
+            }
 
-                if (toggleIdIsFavorite) {
-                    //remove it
-                    user.favorites = user.favorites.filter(emp_id => {
-                        return !(emp_id.equals(toggleId));
-                    });
-                } else {
-                    //add it
-                    user.favorites.push(toggleId);
-                }
-
-                //save the user to DB
-                try {
-                    var savedUser = await user.save();
-                } catch (err) {
-                    return res.status(500).json({
-                        "message": err
-                    });
-                }
-
-                return res.status(200).json({
-                    "favorites": savedUser.favorites
-                });
-
-            })
-        } catch (err) {
-            return res.status(500).json({
-                "message": err
+            var toggleId = req.body.employer_id;
+            var toggleIdIsFavorite = user.favorites.some(emp_id => {
+                return emp_id.equals(toggleId);
             });
-        }
+
+            if (toggleIdIsFavorite) {
+                //remove it
+                user.favorites = user.favorites.filter(emp_id => {
+                    return !(emp_id.equals(toggleId));
+                });
+            } else {
+                //add it
+                user.favorites.push(toggleId);
+            }
+
+            //save the user to DB
+            try {
+                var savedUser = await user.save();
+            } catch (err) {
+                return res.status(500).json({
+                    "message": err
+                });
+            }
+
+            return res.status(200).json({
+                "favorites": savedUser.favorites
+            });
+
+        })
     }
 }
 

--- a/src/api/controllers/users.js
+++ b/src/api/controllers/users.js
@@ -121,4 +121,56 @@ function getFavoritesByAuthUser(req, res) {
     }
 }
 
-export default { getUsers, getUserByAuthUser, getUserById, patchProfileByAuthUser, getFavoritesByAuthUser } 
+// PATCH /users/auth/favorites
+// student only
+// client passes in an objectID of an employer to toggle, receives back the updated list of favorites
+function patchFavoritesByAuthUser(req, res) {
+    if (req.user.user_type !== 'student') {
+        return res.status(403).json({
+            "message": response.onlyStudent
+        });
+    } else {
+        try {
+            User.findById(req.user._id).exec(async function(err, user) {
+            //User.findById(req.user._id).populate('favorites').exec(async function(err, user) {
+                /*return res.status(200).json({
+                    "favorites": user.favorites
+                });*/
+                var toggleId = req.body.employer_id;
+                var toggleIdIsFavorite = user.favorites.some(emp_id => {
+                    return emp_id.equals(toggleId);
+                });
+
+                if (toggleIdIsFavorite) {
+                    //remove it
+                    user.favorites = user.favorites.filter(emp_id => {
+                        return !(emp_id.equals(toggleId));
+                    });
+                } else {
+                    //add it
+                    user.favorites.push(toggleId);
+                }
+
+                //save the user to DB
+                try {
+                    var savedUser = await user.save();
+                } catch (err) {
+                    return res.status(500).json({
+                        "message": err
+                    });
+                }
+
+                return res.status(200).json({
+                    "favorites": savedUser.favorites
+                });
+
+            })
+        } catch (err) {
+            return res.status(500).json({
+                "message": err
+            });
+        }
+    }
+}
+
+export default { getUsers, getUserByAuthUser, getUserById, patchProfileByAuthUser, getFavoritesByAuthUser, patchFavoritesByAuthUser } 

--- a/src/api/controllers/users.js
+++ b/src/api/controllers/users.js
@@ -99,4 +99,26 @@ function patchProfileByAuthUser(req, res) {
     }
 }
 
-export default { getUsers, getUserByAuthUser, getUserById, patchProfileByAuthUser } 
+// GET /users/auth/favorites
+// student only
+function getFavoritesByAuthUser(req, res) {
+    if (req.user.user_type !== 'student') {
+        return res.status(403).json({
+            "message": response.onlyStudent
+        });
+    } else {
+        try {
+            User.findById(req.user._id).populate('favorites').exec(function(err, user) {
+                return res.status(200).json({
+                    "favorites": user.favorites
+                });
+            });
+        } catch (err) {
+            return res.status(500).json({
+                "message": err
+            });
+        }
+    }
+}
+
+export default { getUsers, getUserByAuthUser, getUserById, patchProfileByAuthUser, getFavoritesByAuthUser } 

--- a/src/api/models/users.js
+++ b/src/api/models/users.js
@@ -58,7 +58,11 @@ var studentSchema = new Schema({
     },
     locations_desired: {
         type: [String]
-    }
+    },
+    favorites: [{
+        type: Schema.Types.ObjectId,
+        ref: 'Employer'
+    }]
 }, options);
 
 var recruiterSchema = new Schema({
@@ -80,6 +84,8 @@ var adminSchema = new Schema({
 }, options);
 
 userSchema.plugin(idvalidator);
+studentSchema.plugin(idvalidator);
+recruiterSchema.plugin(idvalidator);
 
 userSchema.methods.setPassword = function (password) {
     this.salt = crypto.randomBytes(16).toString('hex');

--- a/src/api/routes/index.js
+++ b/src/api/routes/index.js
@@ -23,6 +23,7 @@ router.get('/users', auth, userController.getUsers);
 router.get('/users/auth', auth, userController.getUserByAuthUser);
 router.patch('/users/auth/profile', auth, userController.patchProfileByAuthUser);
 router.get('/users/:id', auth, userController.getUserById);
+router.get('/users/auth/favorites', auth, userController.getFavoritesByAuthUser);
 
 // lines
 router.get('/lines/auth', auth, lineController.getLineByAuthUser);

--- a/src/api/routes/index.js
+++ b/src/api/routes/index.js
@@ -24,6 +24,7 @@ router.get('/users/auth', auth, userController.getUserByAuthUser);
 router.patch('/users/auth/profile', auth, userController.patchProfileByAuthUser);
 router.get('/users/:id', auth, userController.getUserById);
 router.get('/users/auth/favorites', auth, userController.getFavoritesByAuthUser);
+router.patch('/users/auth/favorites', auth, userController.patchFavoritesByAuthUser);
 
 // lines
 router.get('/lines/auth', auth, lineController.getLineByAuthUser);


### PR DESCRIPTION
Students now have an array of favorites, type ObjectID.

Client can use the favorites array to check if individual companies are favorites.

Alternatively, if you want the full info for all favorite companies, we have a new route
GET /users/auth/favorites - students only, returns full employer objects of their favorite companies.

*After spring break:
Added another new route
PATCH /users/auth/favorites - students only, usage:

Request an employer_id (string) to be toggled as a favorite.
If it is a favorite, it will be removed.
If it is not a favorite, it will be added.

The response you get will be the updated array of employer_ids, called "favorites".